### PR TITLE
Removed Ratings Field From users Table

### DIFF
--- a/db/migrate/20220226154447_remove_ratings_from_user.rb
+++ b/db/migrate/20220226154447_remove_ratings_from_user.rb
@@ -1,0 +1,5 @@
+class RemoveRatingsFromUser < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :users, :ratings
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_02_26_145013) do
+ActiveRecord::Schema.define(version: 2022_02_26_154447) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -28,7 +28,6 @@ ActiveRecord::Schema.define(version: 2022_02_26_145013) do
     t.integer "postal_code"
     t.text "car_model"
     t.string "car_photo"
-    t.integer "ratings"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
I removed the ratings field from the users table because it is not needed when creating a new user. 