### PR TITLE
Removed car_photo and car_model from table users

### DIFF
--- a/db/migrate/20220226170714_remove_car_model_from_users.rb
+++ b/db/migrate/20220226170714_remove_car_model_from_users.rb
@@ -1,0 +1,5 @@
+class RemoveCarModelFromUsers < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :users, :car_model, :text
+  end
+end

--- a/db/migrate/20220226170754_remove_car_photo_from_users.rb
+++ b/db/migrate/20220226170754_remove_car_photo_from_users.rb
@@ -1,0 +1,5 @@
+class RemoveCarPhotoFromUsers < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :users, :car_photo, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_02_26_163501) do
+ActiveRecord::Schema.define(version: 2022_02_26_170754) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -54,8 +54,6 @@ ActiveRecord::Schema.define(version: 2022_02_26_163501) do
     t.string "avatar"
     t.string "full_name"
     t.integer "postal_code"
-    t.text "car_model"
-    t.string "car_photo"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
I removed these fields from user after consultation with Cedric.
It's better to put them in the offers table, that way if a user has several cars he can just select the model and the picture when he makes a new offer.