### PR TITLE
removed email from users

### DIFF
--- a/db/migrate/20220226171221_add_email_to_users.rb
+++ b/db/migrate/20220226171221_add_email_to_users.rb
@@ -1,5 +1,0 @@
-class AddEmailToUsers < ActiveRecord::Migration[6.1]
-  def change
-    add_column :users, :email, :varchar
-  end
-end


### PR DESCRIPTION
J'ai recu une erreur de duplicata donc j'ai enleve l'email de la table users : 


Resultat de la migration:

rails db:migrate
Running via Spring preloader in process 20825
== 20220226171221 AddEmailToUsers: migrating ==================================
-- add_column(:users, :email, :varchar)
rake aborted!
StandardError: An error has occurred, this and all later migrations canceled:

PG::DuplicateColumn: ERROR:  column "email" of relation "users" already exists
/home/makhtar/code/fallandcoco/UberCopyCat/db/migrate/20220226171221_add_email_to_users.rb:3:in `change'
<internal:/home/makhtar/.rbenv/versions/3.0.3/lib/ruby/3.0.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
<internal:/home/makhtar/.rbenv/versions/3.0.3/lib/ruby/3.0.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
-e:1:in `<main>'

Caused by:
ActiveRecord::StatementInvalid: PG::DuplicateColumn: ERROR:  column "email" of relation "users" already exists
/home/makhtar/code/fallandcoco/UberCopyCat/db/migrate/20220226171221_add_email_to_users.rb:3:in `change'
<internal:/home/makhtar/.rbenv/versions/3.0.3/lib/ruby/3.0.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
<internal:/home/makhtar/.rbenv/versions/3.0.3/lib/ruby/3.0.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
-e:1:in `<main>'

Caused by:
PG::DuplicateColumn: ERROR:  column "email" of relation "users" already exists
/home/makhtar/code/fallandcoco/UberCopyCat/db/migrate/20220226171221_add_email_to_users.rb:3:in `change'
<internal:/home/makhtar/.rbenv/versions/3.0.3/lib/ruby/3.0.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
<internal:/home/makhtar/.rbenv/versions/3.0.3/lib/ruby/3.0.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
-e:1:in `<main>'
Tasks: TOP => db:migrate
(See full trace by running task with --trace)