### PR TITLE
Removed car model and car photo from offers table

### DIFF
--- a/db/migrate/20220226171732_add_model_and_photo_to_offer.rb
+++ b/db/migrate/20220226171732_add_model_and_photo_to_offer.rb
@@ -1,6 +1,0 @@
-class AddModelAndPhotoToOffer < ActiveRecord::Migration[6.1]
-  def change
-    add_column :offers, :car_photo, :string
-    add_column :offers, :car_model, :string
-  end
-end


### PR DESCRIPTION
I removed this migration because the offers table has not yet been created.